### PR TITLE
Added the possibility to append reducers to an existing key with one injectReducer call

### DIFF
--- a/lib/ReduxInjector.js
+++ b/lib/ReduxInjector.js
@@ -82,10 +82,27 @@ function createInjectStore(initialReducers) {
 }
 
 function injectReducer(key, reducer) {
-  var force = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
+  var append = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
+  var force = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : false;
 
   // If already set, do nothing.
-  if ((0, _lodash.has)(store.injectedReducers, key) || force) return;
+  if (Array.isArray(reducer)) {
+    var newReducer = {};
+    reducer.map(function (red, key) {
+      Object.assign(newReducer, red);
+    });
+    reducer = newReducer;
+  }
+  var hasKey = (0, _lodash.has)(store.injectedReducers, key);
+  if (hasKey && !append && !force) return;
+  if (hasKey && append) {
+    var injectedReducers = (0, _lodash.get)(store.injectedReducers, key);
+    if ((typeof injectedReducers === 'undefined' ? 'undefined' : _typeof(injectedReducers)) == 'object') {
+      reducer = Object.assign({}, injectedReducers, reducer);
+    }
+  } else if (!force) {
+    return;
+  }
 
   (0, _lodash.set)(store.injectedReducers, key, reducer);
   store.replaceReducer(combineReducersRecurse(store.injectedReducers));

--- a/src/ReduxInjector.js
+++ b/src/ReduxInjector.js
@@ -48,6 +48,13 @@ export function createInjectStore(initialReducers, ...args) {
 
 export function injectReducer(key, reducer, append = true, force = false) {
   // If already set, do nothing.
+  if(Array.isArray(reducer)) {
+    var newReducer = {};
+    reducer.map((red, key) => {
+      Object.assign(newReducer, red);
+    });
+    reducer = newReducer;
+  }
   var hasKey = has(store.injectedReducers, key);
   if (hasKey && !append && !force) return;
   if(hasKey && append) {

--- a/src/ReduxInjector.js
+++ b/src/ReduxInjector.js
@@ -50,9 +50,11 @@ export function injectReducer(key, reducer, append = true, force = false) {
   // If already set, do nothing.
   var hasKey = has(store.injectedReducers, key);
   if (hasKey && !append && !force) return;
-  if(append) {
+  if(hasKey && append) {
      var injectedReducers = get(store.injectedReducers, key);
-     reducer = Object.assing({}, injectedReducers, reducer);
+     if(typeof(injectedReducers) == 'object') {
+       reducer = Object.assign({}, injectedReducers, reducer);
+     }
    } else if(!force) {
      return;
    }

--- a/src/ReduxInjector.js
+++ b/src/ReduxInjector.js
@@ -1,5 +1,5 @@
 import { createStore, combineReducers } from 'redux';
-import { set, has } from 'lodash';
+import { set, has, get } from 'lodash';
 
 let store = {};
 let combine = combineReducers;

--- a/src/ReduxInjector.js
+++ b/src/ReduxInjector.js
@@ -46,9 +46,16 @@ export function createInjectStore(initialReducers, ...args) {
   return store;
 }
 
-export function injectReducer(key, reducer, force = false) {
+export function injectReducer(key, reducer, append = true, force = false) {
   // If already set, do nothing.
-  if (has(store.injectedReducers, key) || force) return;
+  var hasKey = has(store.injectedReducers, key);
+  if (hasKey && !append && !force) return;
+  if(append) {
+     var injectedReducers = get(store.injectedReducers, key);
+     reducer = Object.assing({}, injectedReducers, reducer);
+   } else if(!force) {
+     return;
+   }
 
   set(store.injectedReducers, key, reducer);
   store.replaceReducer(combineReducersRecurse(store.injectedReducers));


### PR DESCRIPTION
E.g. if you got an object with reducer functions `mediaReducer = {mediaFun1: () => {}, mediaFun2: () => {}}` and want to add all the functions in the object to an existing key `data` in the structure of the reducers: `{data: {pagesFun1: () => {}, pagesFun2: () => {}}}` to get `{data: {pagesFun1: () => {}, pagesFun2: () => {}, mediaFun1:() => {}, mediaFun2:() => {}}}` by doing: `injectReducer('data', mediaReducer);`