### PR TITLE
Adding babel-plugin-lodash to reduce requires with bundlers.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  plugins: ["lodash"],
   presets: ["es2015", "react", "stage-2"]
 }

--- a/lib/ReduxInjector.js
+++ b/lib/ReduxInjector.js
@@ -4,6 +4,14 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 
+var _has2 = require('lodash/has');
+
+var _has3 = _interopRequireDefault(_has2);
+
+var _set2 = require('lodash/set');
+
+var _set3 = _interopRequireDefault(_set2);
+
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
 
 exports.createInjectStore = createInjectStore;
@@ -11,7 +19,7 @@ exports.injectReducer = injectReducer;
 
 var _redux = require('redux');
 
-var _lodash = require('lodash');
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var store = {};
 var combine = _redux.combineReducers;
@@ -85,8 +93,8 @@ function injectReducer(key, reducer) {
   var force = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
   // If already set, do nothing.
-  if ((0, _lodash.has)(store.injectedReducers, key) || force) return;
+  if ((0, _has3.default)(store.injectedReducers, key) || force) return;
 
-  (0, _lodash.set)(store.injectedReducers, key, reducer);
+  (0, _set3.default)(store.injectedReducers, key, reducer);
   store.replaceReducer(combineReducersRecurse(store.injectedReducers));
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-core": "^6.18.2",
+    "babel-plugin-lodash": "^3.2.11",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",


### PR DESCRIPTION
This PR adds [babel-plugin-lodash](https://github.com/lodash/babel-plugin-lodash) to convert lodash import statements to specific parts of lodash so bundlers don't pull the entire lib for a couple of functions.

This could be adressed directly at the import level, but since babel is already used anyway I figured the change that didn't impact coding style would be best.

Thanks for your work!