### PR TITLE
Do not add injectedReducers property to a store

### DIFF
--- a/lib/ReduxInjector.js
+++ b/lib/ReduxInjector.js
@@ -13,8 +13,9 @@ var _redux = require('redux');
 
 var _lodash = require('lodash');
 
-var store = {};
-var combine = _redux.combineReducers;
+var store = {},
+    combine = _redux.combineReducers,
+    injectedReducers = {};
 
 function combineReducersRecurse(reducers) {
   // If this is a leaf or already combined.
@@ -76,7 +77,7 @@ function createInjectStore(initialReducers) {
 
   store = _redux.createStore.apply(undefined, [combineReducersRecurse(initialReducers)].concat(args));
 
-  store.injectedReducers = initialReducers;
+  injectedReducers = initialReducers;
 
   return store;
 }
@@ -85,8 +86,8 @@ function injectReducer(key, reducer) {
   var force = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : false;
 
   // If already set, do nothing.
-  if ((0, _lodash.has)(store.injectedReducers, key) || force) return;
+  if ((0, _lodash.has)(injectedReducers, key) || force) return;
 
-  (0, _lodash.set)(store.injectedReducers, key, reducer);
-  store.replaceReducer(combineReducersRecurse(store.injectedReducers));
+  (0, _lodash.set)(injectedReducers, key, reducer);
+  store.replaceReducer(combineReducersRecurse(injectedReducers));
 }

--- a/src/ReduxInjector.js
+++ b/src/ReduxInjector.js
@@ -1,8 +1,10 @@
 import { createStore, combineReducers } from 'redux';
 import { set, has } from 'lodash';
 
-let store = {};
-let combine = combineReducers;
+let store = {},
+    combine = combineReducers,
+    injectedReducers = {};
+
 
 function combineReducersRecurse(reducers) {
   // If this is a leaf or already combined.
@@ -41,15 +43,15 @@ export function createInjectStore(initialReducers, ...args) {
     ...args
   );
 
-  store.injectedReducers = initialReducers;
+  injectedReducers = initialReducers;
 
   return store;
 }
 
 export function injectReducer(key, reducer, force = false) {
   // If already set, do nothing.
-  if (has(store.injectedReducers, key) || force) return;
+  if (has(injectedReducers, key) || force) return;
 
-  set(store.injectedReducers, key, reducer);
-  store.replaceReducer(combineReducersRecurse(store.injectedReducers));
+  set(injectedReducers, key, reducer);
+  store.replaceReducer(combineReducersRecurse(injectedReducers));
 }


### PR DESCRIPTION
Adding the `injectedReducers` property to a store can cause [problems](https://travis-ci.org/theforeman/foreman/jobs/293031465) when testing connected components using snapshots. 

When adding a new reducer, each snapshots will need to be regenerated because the `injectedReducers`  property on injected store changes. This will become painful as an application grows.

If we want to expose the `injectedReducers` to the outside world, I can add a function to a store that does it for us.

Let me know what you think.